### PR TITLE
Fix dungeon generation and expose game instance

### DIFF
--- a/game.js
+++ b/game.js
@@ -126,5 +126,7 @@ class Game {
   }
 }
 
-window.onload = () => new Game();
-window.game = this;
+window.onload = () => {
+  window.game = new Game();
+};
+


### PR DESCRIPTION
## Summary
- expose created game instance via `window.game`
- reintroduce chunk generation logic with memory and regeneration helpers

## Testing
- `node -e "import('./map.js').then(()=>console.log('loaded')).catch(e=>console.error(e))"`
- `node -e "import('./game.js').then(()=>console.log('game ok')).catch(e=>console.error(e.message))"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6859cbf92c848332ad20045764af1d64