### PR TITLE
Fix game canvas usage

### DIFF
--- a/game.js
+++ b/game.js
@@ -13,10 +13,13 @@ const CANVAS_HEIGHT  = 480;
 class Game {
   constructor() {
     /* — canvas — */
-    this.canvas = document.createElement('canvas');
+    this.canvas = document.getElementById('gameCanvas');
+    if (!this.canvas) {
+      this.canvas = document.createElement('canvas');
+      document.body.appendChild(this.canvas);
+    }
     this.canvas.width  = CANVAS_WIDTH;
     this.canvas.height = CANVAS_HEIGHT;
-    document.body.appendChild(this.canvas);
     this.ctx = this.canvas.getContext('2d');
 
     /* — карта — */


### PR DESCRIPTION
## Summary
- use existing `#gameCanvas` element instead of creating a duplicate canvas

## Testing
- `puppeteer` script to open the page and verify only a single canvas is present

------
https://chatgpt.com/codex/tasks/task_e_6859d408e9848332a388b8f2cd536f07