### PR TITLE
Add chunk connectivity test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Not-Dead-Yet
+
+## Connectivity Test
+
+Run a small script to verify that two adjacent chunks share a corridor at their common edge:
+
+```bash
+node scripts/testChunkConnectivity.js
+```
+
+The script exits with a non-zero status if no connecting corridor is found.

--- a/map.js
+++ b/map.js
@@ -376,4 +376,5 @@ class GameMap {
 }
 
 // делаем доступным в глобальной области, чтобы game.js увидел
-window.GameMap = GameMap;
+if (typeof window !== 'undefined') window.GameMap = GameMap;
+if (typeof module !== 'undefined' && module.exports) module.exports = GameMap;

--- a/scripts/testChunkConnectivity.js
+++ b/scripts/testChunkConnectivity.js
@@ -1,0 +1,30 @@
+const GameMap = require('../map');
+
+const gm = new GameMap();
+const cx1 = 0, cy1 = 0;
+const cx2 = 1, cy2 = 0; // adjacent chunk to the east
+
+gm.ensureChunk(cx1, cy1);
+gm.ensureChunk(cx2, cy2);
+
+const key1 = `${cx1},${cy1}`;
+const key2 = `${cx2},${cy2}`;
+const chunk1 = gm.chunks.get(key1).tiles;
+const chunk2 = gm.chunks.get(key2).tiles;
+
+const S = gm.chunkSize;
+let connected = false;
+for (let y = 0; y < S; y++) {
+  const left  = chunk1[y][S-1] === 1 || chunk1[y][S-2] === 1;
+  const right = chunk2[y][0] === 1 || chunk2[y][1] === 1;
+  if (left && right) {
+    connected = true;
+    break;
+  }
+}
+
+if (!connected) {
+  console.error('Chunks (0,0) and (1,0) do not share a corridor.');
+  process.exit(1);
+}
+console.log('Chunks are connected by a corridor.');


### PR DESCRIPTION
## Summary
- export `GameMap` for Node usage
- create `scripts/testChunkConnectivity.js` to verify corridor connection between adjacent chunks
- document how to run the test

## Testing
- `node scripts/testChunkConnectivity.js` *(fails when chunks aren't connected)*

------
https://chatgpt.com/codex/tasks/task_e_685c2dc8f1b48332b206e12bffe78e09