### PR TITLE
Enable Node module export

### DIFF
--- a/map.js
+++ b/map.js
@@ -375,5 +375,6 @@ class GameMap {
   }
 }
 
-// делаем доступным в глобальной области, чтобы game.js увидел
-window.GameMap = GameMap;
+// Делать класс доступным для разных окружений
+if (typeof module !== 'undefined') module.exports = GameMap;
+if (typeof window !== 'undefined') window.GameMap = GameMap;


### PR DESCRIPTION
## Summary
- allow `map.js` to be used in Node for tests

## Testing
- `node -e "console.log(typeof require('./map.js'));"`


------
https://chatgpt.com/codex/tasks/task_e_685c2dcdf1708332b8215ae2dd934849