### PR TITLE
Add regeneration connectivity test

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ node scripts/testChunkConnectivity.js
 ```
 
 The script exits with a non-zero status if no connecting corridor is found.
+
+## Regeneration Connectivity Test
+
+Verify that corridor connections survive chunk regeneration:
+
+```bash
+node scripts/testRegenerationConnectivity.js
+```
+
+This script exits with a non-zero status if the connection is lost after regeneration.

--- a/scripts/testRegenerationConnectivity.js
+++ b/scripts/testRegenerationConnectivity.js
@@ -1,0 +1,37 @@
+const GameMap = require('../map');
+
+const gm = new GameMap();
+const cx1 = 0, cy1 = 0;
+const cx2 = 1, cy2 = 0; // adjacent chunk to the east
+
+gm.ensureChunk(cx1, cy1);
+gm.ensureChunk(cx2, cy2);
+
+const key1 = `${cx1},${cy1}`;
+const key2 = `${cx2},${cy2}`;
+
+// Regenerate the second chunk with no FOV preservation
+function emptyFOV() { return new Set(); }
+const dummyPlayer = { x: 0, y: 0, angle: 0 };
+
+gm.regenerateChunksPreserveFOV(new Set([key2]), emptyFOV, dummyPlayer);
+
+const chunk1 = gm.chunks.get(key1).tiles;
+const chunk2 = gm.chunks.get(key2).tiles;
+
+const S = gm.chunkSize;
+let connected = false;
+for (let y = 0; y < S; y++) {
+  const left  = chunk1[y][S-1] === 1 || chunk1[y][S-2] === 1;
+  const right = chunk2[y][0] === 1 || chunk2[y][1] === 1;
+  if (left && right) {
+    connected = true;
+    break;
+  }
+}
+
+if (!connected) {
+  console.error('Corridor connection lost after regeneration.');
+  process.exit(1);
+}
+console.log('Corridor connection preserved after regeneration.');


### PR DESCRIPTION
## Summary
- add `testRegenerationConnectivity.js` to ensure corridor connections survive regeneration
- update README with instructions for running the new test

## Testing
- `node scripts/testChunkConnectivity.js`
- `node scripts/testRegenerationConnectivity.js`


------
https://chatgpt.com/codex/tasks/task_e_685c3c8e6e44833288989cb0ce812c3e