### PR TITLE
Add extraSeed option for chunk regeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,17 @@ node scripts/testMultiEdgeRegeneration.js
 ```
 
 The script regenerates each neighbouring chunk several times and exits with a non-zero status if any corridor connection disappears.
+
+## Regenerating with a Different Layout
+
+Both `ensureChunk` and `regenerateChunksPreserveFOV` accept an optional
+`extraSeed` parameter. Passing a different value forces the procedural generator
+to build a new layout for the chunk:
+
+```javascript
+const key = '1,0';
+gameMap.regenerateChunksPreserveFOV(new Set([key]), computeFOV, player, Date.now());
+```
+
+Use any integer value for `extraSeed` to trigger a fresh layout when the chunk
+is regenerated.

--- a/map.js
+++ b/map.js
@@ -60,13 +60,13 @@ class GameMap {
    * Убедиться, что чанк (cx,cy) есть в this.chunks.
    * Если нет — сгенерировать сразу tiles и meta.
    */
-  ensureChunk(cx, cy) {
+  ensureChunk(cx, cy, extraSeed = 0) {
     const key = `${cx},${cy}`;
     if (this.chunks.has(key) || this.generating.has(key)) return;
     this.generating.add(key);
 
     // 1) Генерим саму сетку пола/стен
-    const seed = ((cx * 73856093) ^ (cy * 19349663)) >>> 0;
+    const seed = ((cx * 73856093) ^ (cy * 19349663) ^ extraSeed) >>> 0;
     const rng  = mulberry32(seed);
     const tiles = this._generateChunk(cx, cy, rng);
 
@@ -106,7 +106,7 @@ class GameMap {
    * — генерируем новый (ensureChunk)
    * — заливаем туда сохранённые tile/meta
    */
-  regenerateChunksPreserveFOV(keys, computeFOV, player) {
+  regenerateChunksPreserveFOV(keys, computeFOV, player, extraSeed = 0) {
     // сначала FOV текущей позиции
     const vis = computeFOV(player.x, player.y, player.angle);
 
@@ -138,7 +138,7 @@ class GameMap {
       this.chunks.delete(key);
 
       // 3) генерим снова
-      this.ensureChunk(cx, cy);
+      this.ensureChunk(cx, cy, extraSeed);
 
       // 4) возвращаем сохранённые квадратики
       const fresh = this.chunks.get(key);


### PR DESCRIPTION
## Summary
- allow passing an optional `extraSeed` to `ensureChunk`
- regenerate chunks with a custom seed via `regenerateChunksPreserveFOV`
- document how to trigger alternate layouts

## Testing
- `node scripts/testChunkConnectivity.js`
- `node scripts/testRegenerationConnectivity.js`
- `node scripts/testMultiEdgeRegeneration.js`


------
https://chatgpt.com/codex/tasks/task_e_685c4939d0508332b676eac5be417465