### PR TITLE
Add geometry test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ node scripts/testMultiEdgeRegeneration.js
 
 The script regenerates each neighbouring chunk several times and exits with a non-zero status if any corridor connection disappears.
 
+## Geometry Consistency Test
+
+Generate a few chunks and verify basic geometric invariants:
+
+```bash
+node scripts/testGeometry.js
+```
+
+The script fails if corridor width is not two tiles everywhere or if any room cell lacks a surrounding wall where no door is present.
+
 ## Regenerating with a Different Layout
 
 Both `ensureChunk` and `regenerateChunksPreserveFOV` accept an optional

--- a/scripts/testGeometry.js
+++ b/scripts/testGeometry.js
@@ -1,0 +1,55 @@
+const GameMap = require('../map');
+
+const gm = new GameMap();
+const WALL = 0, CORR = 1, ROOM = 2, DOOR = 3;
+const S = gm.chunkSize;
+const errors = [];
+
+function checkChunk(cx, cy) {
+  gm.ensureChunk(cx, cy);
+  const tiles = gm.chunks.get(`${cx},${cy}`).tiles;
+  for (let y = 0; y < S; y++) {
+    for (let x = 0; x < S; x++) {
+      const t = tiles[y][x];
+      if (t === CORR) {
+        const horiz = (x > 0 && tiles[y][x - 1] === CORR) ||
+                      (x < S - 1 && tiles[y][x + 1] === CORR);
+        const vert  = (y > 0 && tiles[y - 1][x] === CORR) ||
+                      (y < S - 1 && tiles[y + 1][x] === CORR);
+        if (!(horiz && vert)) {
+          errors.push(`Corridor width broken at chunk ${cx},${cy} tile ${x},${y}`);
+        }
+      }
+      if (t === ROOM) {
+        const dirs = [
+          [1, 0], [-1, 0], [0, 1], [0, -1]
+        ];
+        for (const [dx, dy] of dirs) {
+          const nx = x + dx, ny = y + dy;
+          if (nx < 0 || ny < 0 || nx >= S || ny >= S) continue;
+          const nt = tiles[ny][nx];
+          if (nt === CORR) {
+            errors.push(`Room directly touches corridor at chunk ${cx},${cy} tile ${x},${y}`);
+          } else if (nt === DOOR) {
+            const bx = nx + dx, by = ny + dy;
+            if (bx >= 0 && by >= 0 && bx < S && by < S && tiles[by][bx] !== CORR) {
+              errors.push(`Door at chunk ${cx},${cy} tile ${nx},${ny} does not lead to corridor`);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+for (let cx = -1; cx <= 1; cx++) {
+  for (let cy = -1; cy <= 1; cy++) {
+    checkChunk(cx, cy);
+  }
+}
+
+if (errors.length) {
+  for (const e of errors) console.error(e);
+  process.exit(1);
+}
+console.log('Geometry constraints satisfied.');


### PR DESCRIPTION
## Summary
- add a geometry check script that validates corridor width and room walls
- document how to run the new test

## Testing
- `node scripts/testChunkConnectivity.js`
- `node scripts/testRegenerationConnectivity.js`
- `node scripts/testMultiEdgeRegeneration.js`
- `node scripts/testGeometry.js` *(fails: Room directly touches corridor, Door does not lead to corridor)*

------
https://chatgpt.com/codex/tasks/task_e_685c53402a1c833286bb87b9a982eb6a