### PR TITLE
Limit room doors to max three sides

### DIFF
--- a/map.js
+++ b/map.js
@@ -355,8 +355,8 @@ class GameMap {
     for (let room of rooms) {
       const used = new Set();
       let doorNum = Math.max(1, Math.floor((room.w + room.h)/6));
-      if(rng()<0.5) doorNum++;
-      doorNum = Math.min(4, doorNum);
+      if (rng() < 0.5) doorNum++;
+      doorNum = Math.min(3, doorNum); // doors on 1-3 sides only
       let placed = 0;
       for (let i=0; i<doorNum; i++) {
         const d = carveDoor(room, used);


### PR DESCRIPTION
## Summary
- rooms can only place doors on up to three different walls

## Testing
- `node -e "require('./map.js');"`

------
https://chatgpt.com/codex/tasks/task_e_685d2847543c83329be0f9dab17e19de